### PR TITLE
Inspect rule-based error categories

### DIFF
--- a/02_error_analysis.ipynb
+++ b/02_error_analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 1,
    "id": "d8e6a601",
    "metadata": {},
    "outputs": [
@@ -33,6 +33,9 @@
        "      <th>bilstm</th>\n",
        "      <th>bilstm_cv</th>\n",
        "      <th>rule_based</th>\n",
+       "      <th>robbert_512_2</th>\n",
+       "      <th>robbert_128_2</th>\n",
+       "      <th>robbert_32_2</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -40,6 +43,9 @@
        "      <th>0</th>\n",
        "      <td>DL1111_32_46</td>\n",
        "      <td>DL</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
@@ -53,6 +59,9 @@
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -62,11 +71,17 @@
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>DL1112_22_28</td>\n",
        "      <td>DL</td>\n",
+       "      <td>negated</td>\n",
+       "      <td>negated</td>\n",
+       "      <td>negated</td>\n",
        "      <td>negated</td>\n",
        "      <td>negated</td>\n",
        "      <td>negated</td>\n",
@@ -80,21 +95,31 @@
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
        "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
+       "      <td>not negated</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "        entity_id category        label       bilstm    bilstm_cv   rule_based\n",
-       "0    DL1111_32_46       DL  not negated  not negated  not negated  not negated\n",
-       "1  DL1111_272_280       DL  not negated  not negated  not negated  not negated\n",
-       "2  DL1111_363_377       DL  not negated  not negated  not negated  not negated\n",
-       "3    DL1112_22_28       DL      negated      negated      negated      negated\n",
-       "4    DL1113_59_67       DL  not negated  not negated  not negated  not negated"
+       "        entity_id category        label       bilstm    bilstm_cv  \\\n",
+       "0    DL1111_32_46       DL  not negated  not negated  not negated   \n",
+       "1  DL1111_272_280       DL  not negated  not negated  not negated   \n",
+       "2  DL1111_363_377       DL  not negated  not negated  not negated   \n",
+       "3    DL1112_22_28       DL      negated      negated      negated   \n",
+       "4    DL1113_59_67       DL  not negated  not negated  not negated   \n",
+       "\n",
+       "    rule_based robbert_512_2 robbert_128_2 robbert_32_2  \n",
+       "0  not negated   not negated   not negated  not negated  \n",
+       "1  not negated   not negated   not negated          NaN  \n",
+       "2  not negated   not negated   not negated          NaN  \n",
+       "3      negated       negated       negated      negated  \n",
+       "4  not negated   not negated   not negated  not negated  "
       ]
      },
-     "execution_count": 107,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1158,10 +1183,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "fecc4bb4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "191"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "FNs_rule = results[(results.label == 'negated') & (results.rule_based == 'not negated')]['entity_id']\n",
     "len(FNs_rule)"
@@ -1169,7 +1205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "5cea167c",
    "metadata": {},
    "outputs": [],
@@ -1206,6 +1242,184 @@
     "    - \"pleit tegen\" (4 cases)\n",
     "    - \"niet voorafgegaan\" (8 cases)\n",
     "    - words like \"niet\" en \"geen\" that occur directly next to `ENT`, so have a scope of 1; probably too many false positives with broader scope (12 cases)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36361fdf-617d-4dd7-a06f-b7732ba8ca11",
+   "metadata": {},
+   "source": [
+    "### Categories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9946db50-00eb-4810-8025-06164e82f79c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entity_id</th>\n",
+       "      <th>pattern</th>\n",
+       "      <th>category</th>\n",
+       "      <th>trigger</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>DL1156_161_172</td>\n",
+       "      <td>ENT zijn negatief</td>\n",
+       "      <td>missing variation</td>\n",
+       "      <td>negatief</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>DL1163_0_8</td>\n",
+       "      <td>ENT treedt niet op</td>\n",
+       "      <td>missing trigger</td>\n",
+       "      <td>treden niet op</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>DL1167_76_82</td>\n",
+       "      <td>ENT kan niet worden herinnerd</td>\n",
+       "      <td>negation of different term</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>DL1201_0_8</td>\n",
+       "      <td>ENT treedt niet op</td>\n",
+       "      <td>missing trigger</td>\n",
+       "      <td>treden niet op</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>DL1204_26_34</td>\n",
+       "      <td>is er nooit een ENT</td>\n",
+       "      <td>missing variation</td>\n",
+       "      <td>nooit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        entity_id                        pattern                    category  \\\n",
+       "0  DL1156_161_172              ENT zijn negatief           missing variation   \n",
+       "1      DL1163_0_8             ENT treedt niet op             missing trigger   \n",
+       "2    DL1167_76_82  ENT kan niet worden herinnerd  negation of different term   \n",
+       "3      DL1201_0_8             ENT treedt niet op             missing trigger   \n",
+       "4    DL1204_26_34            is er nooit een ENT           missing variation   \n",
+       "\n",
+       "          trigger  \n",
+       "0        negatief  \n",
+       "1  treden niet op  \n",
+       "2             NaN  \n",
+       "3  treden niet op  \n",
+       "4           nooit  "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load entity_id, snippet containing error, error category, and (absence of) trigger involved\n",
+    "errors_FN = pd.read_csv(result_dir / 'false-negatives_rule-based.csv', sep = ';')\n",
+    "errors_FN.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "346295f8-2f86-44e5-a09d-d28a514aec8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_category_counts(df, err_type):\n",
+    "    cnt = df['category'].value_counts()\n",
+    "    tot = df.shape[0]\n",
+    "    print(f'{err_type} ({tot} total)')\n",
+    "    print(pd.concat([cnt.rename('count'),\n",
+    "               (cnt / tot * 100).rename('percentage')],\n",
+    "              axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a3964f77-a614-4014-a4a8-ee3e4a7d8c27",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False negatives (191 total)\n",
+      "                              count  percentage\n",
+      "missing trigger                  86   45.026178\n",
+      "annotation error                 29   15.183246\n",
+      "missing variation                22   11.518325\n",
+      "missing direction                21   10.994764\n",
+      "sentence splitting               13    6.806283\n",
+      "uncertainty                       6    3.141361\n",
+      "wrong modality                    4    2.094241\n",
+      "complex trigger                   3    1.570681\n",
+      "trigger overlaps with entity      2    1.047120\n",
+      "negation of different term        2    1.047120\n",
+      "termination trigger               2    1.047120\n",
+      "spelling error                    1    0.523560\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_category_counts(errors_FN, 'False negatives')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "633054ec-0f67-4188-ac91-0f041d552250",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_example_error(df, category):\n",
+    "    smpl = df[df['category'] == category].sample()\n",
+    "    get_document_text(smpl.entity_id.values[0], dcc_dir, results.iloc[:,0:3]);\n",
+    "    print(smpl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a05e8003-4c46-4dc3-8ea3-4802a298715e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_example_error(errors_FN, 'sentence splitting')"
    ]
   },
   {
@@ -1249,14 +1463,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b6e93dc8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "2acc8c76",
    "metadata": {},
@@ -1265,6 +1471,153 @@
     "- \"wel\" should be a termination trigger\n",
     "- triggers like \"geen\" and \"niet\" should have a reduced scope (maybe even just 1?)\n",
     "    - might also help to add punctuation like `,` and `;` as termination triggers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11ef6cc3-321b-4b03-8496-85dc2111e1a7",
+   "metadata": {},
+   "source": [
+    "### Categories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "d0c5bf86-2758-44bc-97b3-1645515d363e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entity_id</th>\n",
+       "      <th>pattern</th>\n",
+       "      <th>category</th>\n",
+       "      <th>trigger</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>DL1147_255_262</td>\n",
+       "      <td>Zonder dat […] ENT heeft plaatsgevonden</td>\n",
+       "      <td>annotation error</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>DL1184_760_766</td>\n",
+       "      <td>niet hetzelfde is als ENT</td>\n",
+       "      <td>missing pseudo trigger</td>\n",
+       "      <td>niet hetzelfde</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>DL1188_212_217</td>\n",
+       "      <td>niet voldoende genezend ENT</td>\n",
+       "      <td>missing pseudo trigger</td>\n",
+       "      <td>niet voldoende</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>DL1188_222_235</td>\n",
+       "      <td>niet voldoende genezend ENT</td>\n",
+       "      <td>missing pseudo trigger</td>\n",
+       "      <td>niet voldoende</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>DL1219_127_141</td>\n",
+       "      <td>geen […], wel ENT</td>\n",
+       "      <td>missing termination trigger</td>\n",
+       "      <td>wel</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        entity_id                                  pattern  \\\n",
+       "0  DL1147_255_262  Zonder dat […] ENT heeft plaatsgevonden   \n",
+       "1  DL1184_760_766                niet hetzelfde is als ENT   \n",
+       "2  DL1188_212_217              niet voldoende genezend ENT   \n",
+       "3  DL1188_222_235              niet voldoende genezend ENT   \n",
+       "4  DL1219_127_141                        geen […], wel ENT   \n",
+       "\n",
+       "                      category         trigger  \n",
+       "0             annotation error             NaN  \n",
+       "1       missing pseudo trigger  niet hetzelfde  \n",
+       "2       missing pseudo trigger  niet voldoende  \n",
+       "3       missing pseudo trigger  niet voldoende  \n",
+       "4  missing termination trigger             wel  "
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load entity_id, snippet containing error, error category, and (absence of) trigger involved\n",
+    "errors_FP = pd.read_csv(result_dir / 'false-positives_rule-based.csv', sep = ';')\n",
+    "errors_FP.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "66df3427-71dc-441d-af73-40743e7c7c80",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False positives (336 total)\n",
+      "                             count  percentage\n",
+      "scope exceeded                  84   25.000000\n",
+      "negation of different term      66   19.642857\n",
+      "no negation of noun             52   15.476190\n",
+      "missing pseudo trigger          49   14.583333\n",
+      "missing termination trigger     31    9.226190\n",
+      "list                            19    5.654762\n",
+      "wrong modality                  13    3.869048\n",
+      "annotation error                12    3.571429\n",
+      "uncertainty                      9    2.678571\n",
+      "wrong direction                  1    0.297619\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_category_counts(errors_FP, 'False positives')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de792f15-9868-490d-81b1-9b9463021570",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_example_error(errors_FP, 'missing termination trigger')"
    ]
   },
   {
@@ -1434,7 +1787,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
Added error categories to the list of false positives and negatives I had for the rule based model. These are two csv's where for each error I logged:
- the `entity_id`
- the text snippet containing the entity (masked as `ENT`) and the negation term
- the error category (e.g. "negation of different term")
- the trigger (i.e. negation term) involved (e.g. "geen aanwijzingen")

For example:
| entity_id  | pattern            | category        | trigger        |
|------------|--------------------|-----------------|----------------|
| DL1163_0_8 | ENT treedt niet op | missing trigger | treden niet op |


These files are for now only on surfdrive (in `negation_detection/rule-based`) until we decide on the formatting / whether we want to combine them with the errors made by the other models.